### PR TITLE
GH-45: Add `@Import(ScriptVarGenConfig.class)`

### DIFF
--- a/groovy-filter-app-dependencies/pom.xml
+++ b/groovy-filter-app-dependencies/pom.xml
@@ -1,30 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.springframework.cloud.stream.app</groupId>
-    <artifactId>groovy-filter-app-dependencies</artifactId>
-    <version>1.1.2.BUILD-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>groovy-filter-app-dependencies</name>
-    <description>Spring Cloud Stream Groovy Filter App Dependencies</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>groovy-filter-app-dependencies</artifactId>
+	<version>1.1.2.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>groovy-filter-app-dependencies</name>
+	<description>Spring Cloud Stream Groovy Filter App Dependencies</description>
 
-    <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>1.2.1.RELEASE</version>
-        <relativePath />
-    </parent>
+	<parent>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>1.2.1.RELEASE</version>
+		<relativePath/>
+	</parent>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-processor-groovy-filter</artifactId>
-                <version>1.1.2.BUILD-SNAPSHOT</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-<profiles>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-processor-groovy-filter</artifactId>
+				<version>1.1.2.BUILD-SNAPSHOT</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>groovy-filter-app-starters-build</artifactId>
 	<version>1.1.2.BUILD-SNAPSHOT</version>
@@ -28,7 +29,8 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-<profiles>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-stream-processor-groovy-filter/README.adoc
+++ b/spring-cloud-starter-stream-processor-groovy-filter/README.adoc
@@ -1,7 +1,7 @@
 //tag::ref-doc[]
 = Groovy Filter Processor
 
-A Processor module that retains or discards messages according to a predicate, expressed as a Groovy script.
+A Processor application that retains or discards messages according to a predicate, expressed as a Groovy script.
 
 == Options
 

--- a/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-groovy-filter/src/main/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorConfiguration.java
@@ -21,18 +21,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.support.PropertiesLoaderUtils;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
-import org.springframework.integration.scripting.DefaultScriptVariableGenerator;
 import org.springframework.integration.scripting.ScriptVariableGenerator;
 import org.springframework.scripting.support.ResourceScriptSource;
-import org.springframework.util.CollectionUtils;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A Processor module that retains or discards messages according to a predicate,
@@ -42,9 +36,11 @@ import java.util.Map;
  * @author Mark Fisher
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @EnableBinding(Processor.class)
 @EnableConfigurationProperties(GroovyFilterProcessorProperties.class)
+@Import(ScriptVariableGeneratorConfiguration.class)
 public class GroovyFilterProcessorConfiguration {
 
 	@Autowired

--- a/spring-cloud-starter-stream-processor-groovy-filter/src/test/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorApplicationIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-groovy-filter/src/test/java/org/springframework/cloud/stream/app/groovy/filter/processor/GroovyFilterProcessorApplicationIntegrationTests.java
@@ -16,26 +16,27 @@
 
 package org.springframework.cloud.stream.app.groovy.filter.processor;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
-import org.springframework.cloud.stream.annotation.Bindings;
-import org.springframework.cloud.stream.messaging.Processor;
-import org.springframework.cloud.stream.test.binder.MessageCollector;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Integration Tests for GroovyFilterProcessor.
@@ -43,22 +44,22 @@ import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.
  * @author Eric Bottard
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(
-		classes = GroovyFilterProcessorApplicationIntegrationTests.GroovyFilterProcessorApplication.class)
-@WebIntegrationTest(randomPort = true)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @DirtiesContext
 public abstract class GroovyFilterProcessorApplicationIntegrationTests {
 
 	@Autowired
-	@Bindings(GroovyFilterProcessorConfiguration.class)
 	protected Processor channels;
 
 	@Autowired
 	protected MessageCollector collector;
 
-	@IntegrationTest({"groovy-filter.script=script.groovy", "groovy-filter.variables=threshold=5"})
+	@TestPropertySource(properties = {
+			"groovy-filter.script=script.groovy",
+			"groovy-filter.variables=threshold=5" })
 	public static class UsingScriptIntegrationTests extends GroovyFilterProcessorApplicationIntegrationTests {
 
 		@Test
@@ -71,7 +72,10 @@ public abstract class GroovyFilterProcessorApplicationIntegrationTests {
 		}
 	}
 
-	@SpringBootApplication
+	// Avoid @SpringBootApplication with its @ComponentScan
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@Import(GroovyFilterProcessorConfiguration.class)
 	public static class GroovyFilterProcessorApplication {
 
 	}

--- a/spring-cloud-starter-stream-processor-groovy-filter/src/test/resources/script.groovy
+++ b/spring-cloud-starter-stream-processor-groovy-filter/src/test/resources/script.groovy
@@ -1,17 +1,1 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 payload.length() > threshold.toInteger()


### PR DESCRIPTION
Fixes GH-45 (https://github.com/spring-cloud-stream-app-starters/app-starters-release/issues/45)

Since we have `GroovyFilterProcessorApplicationIntegrationTests` in the same package as an original `GroovyFilterProcessorConfiguration` and uses `@ComponentScan` from the `@SpringBootApplication`,
 we pick up unimported `ScriptVariableGeneratorConfiguration` as well as for test environment.
In the real world `@SpringBootApplication` might be on a different package therefore  unimported `ScriptVariableGeneratorConfiguration` isn't scanned.

* Add `@Import(ScriptVariableGeneratorConfiguration.class)` to the `GroovyFilterProcessorConfiguration`
* Modify `GroovyFilterProcessorApplicationIntegrationTests` do not scan packages
* Resolve deprecations according Spring Boot upgrade
* poms and README polishing